### PR TITLE
Remove python 2 and add 3.8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - "2.7"
   - "3.5"
+  - "3.8"
 
 # install python dependencies including this package in the travis
 # virtualenv


### PR DESCRIPTION
Remove python 2.7 from the CI since python 2.7 is no longer supported.
Add latest version of python 3.8 to the CI.