### PR TITLE
Fix YAML warning

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -7,18 +7,12 @@ import os
 import subprocess
 
 import yaml
-import sys
 from colors import green, red
 
 
-PY3 = int(sys.version[0]) == 3
-
-if PY3:
-    unicode = str
-
-root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-def run_test(command):
-    wrapped_command = "cd %s && %s" % (root_dir, command)
+def run_test(command, directory):
+    """Execute a command that runs a test"""
+    wrapped_command = "cd %s && %s" % (directory, command)
     pipe = subprocess.Popen(
         wrapped_command, shell=True,
     )
@@ -29,22 +23,21 @@ def run_test(command):
         print(red("TEST FAILED"))
     return pipe.returncode
 
+
+root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
 # load the script tests from the .travis.yml file
 with open(os.path.join(root_dir, '.travis.yml')) as stream:
-    travis_yml = yaml.load_all(stream.read())
-if PY3:
-    config = next(travis_yml)
-else:
-    config = travis_yml.next()
-tests = config['script']
+    travis_yml = yaml.safe_load(stream.read())
+tests = travis_yml['script']
 
 # run the tests
-if isinstance(tests, unicode):
-    returncode = run_test(tests)
+if isinstance(tests, str):
+    returncode = run_test(tests, root_dir)
 elif isinstance(tests, (list, tuple)):
     returncode = 0
     for test in tests:
-        returncode += run_test(test)
+        returncode += run_test(test, root_dir)
 
 if returncode == 0:
     print(green("ALL TESTS PASSED"))


### PR DESCRIPTION
Use yaml.safe_load to avoid a warning and drop python 2.7 support