### PR TITLE
small bug fix for the spacy test params document_list and document_names

### DIFF
--- a/tests/test_detector_spacy.py
+++ b/tests/test_detector_spacy.py
@@ -41,7 +41,7 @@ class SpacyDetectorTestCase(unittest.TestCase, BaseTestCase):
     def _assert_filth_type_and_pos(self, doc_list, beg_end_list, filth_class):
         doc_names = [str(x) for x in range(len(doc_list))]
 
-        filth_list = list(self.detector.iter_filth_documents(document_list=doc_names, document_names=doc_list))
+        filth_list = list(self.detector.iter_filth_documents(document_list=doc_list, document_names=doc_names))
 
         for filth, beg_end in zip(filth_list, beg_end_list):
             self.assertIsInstance(filth, filth_class)


### PR DESCRIPTION
super small fix for the test_detector_spacy.py where params for document_list and document_names were reversed 