### PR TITLE
Improve the classification report

### DIFF
--- a/scrubadub/detectors/tagged.py
+++ b/scrubadub/detectors/tagged.py
@@ -47,9 +47,9 @@ class TaggedEvaluationFilthDetector(Detector):
     ... ])
     >>> filth_list = list(scrubber.iter_filth("Hello I am Tom"))
     >>> print(scrubadub.comparison.get_filth_classification_report(filth_list))
-    filth          detector     locale    precision    recall  f1-score   support
+    filth    detector         locale      precision    recall  f1-score   support
     <BLANKLINE>
-     name     name_detector      en_US         1.00      1.00      1.00         1
+    name     name_detector    en_US            1.00      1.00      1.00         1
     <BLANKLINE>
                                 accuracy                           1.00         1
                                macro avg       1.00      1.00      1.00         1

--- a/scrubadub/utils.py
+++ b/scrubadub/utils.py
@@ -1,7 +1,7 @@
 import re
 import locale as locale_module
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 try:
     unicode  # type: ignore  # tell mypy to ignore the fact that this doesnt exist in python3
@@ -98,3 +98,13 @@ def locale_split(locale: str) -> Tuple[Optional[str], Optional[str]]:
         raise ValueError('Locale does not match expected format.')
 
     return match.group('language').lower(), match.group('region').upper()
+
+
+class ToStringMixin(object):
+    def _to_string(self, attributes: List[str]) -> str:
+        item_attributes = [
+            "{}={}".format(item, getattr(self, item, None).__repr__())
+            for item in attributes
+            if getattr(self, item, None) is not None
+        ]
+        return "<{} {}>".format(self.__class__.__name__, " ".join(item_attributes))

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -24,7 +24,7 @@ class ComparisonTestCase(unittest.TestCase):
             AddressFilth(beg=100, end=103, text='123', detector_name='address_det'),
         ]
         grouper = scrubadub.comparison.FilthGrouper()
-        grouper.add_positions(filths)
+        grouper.add_filths(filths)
 
         self.assertEqual(3, len(grouper.types))
 
@@ -80,10 +80,10 @@ class ComparisonTestCase(unittest.TestCase):
             ),
             TaggedEvaluationFilth(beg=5, end=10, text='12345', comparison_type='phone'),
             MergedFilth(
-                PhoneFilth(beg=5, end=9, text='1234', detector_name='phone'),
-                TaggedEvaluationFilth(beg=5, end=9, text='1234', comparison_type='phone'),
+                PhoneFilth(beg=12, end=16, text='1234', detector_name='phone'),
+                TaggedEvaluationFilth(beg=12, end=16, text='1234', comparison_type='phone'),
             ),
-            TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='phone'),
+            TaggedEvaluationFilth(beg=20, end=25, text='12345', comparison_type='phone'),
         ]
 
         self.assertEqual(
@@ -135,10 +135,10 @@ class ComparisonTestCase(unittest.TestCase):
             PhoneFilth(beg=0, end=4, text='1234', detector_name='phone_v1'),
             TaggedEvaluationFilth(beg=5, end=10, text='12345', comparison_type='phone'),
             MergedFilth(
-                PhoneFilth(beg=5, end=9, text='1234', detector_name='phone_v1'),
-                TaggedEvaluationFilth(beg=5, end=9, text='1234', comparison_type='phone'),
+                PhoneFilth(beg=12, end=16, text='1234', detector_name='phone_v1'),
+                TaggedEvaluationFilth(beg=12, end=16, text='1234', comparison_type='phone'),
             ),
-            TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='phone'),
+            TaggedEvaluationFilth(beg=20, end=25, text='12345', comparison_type='phone'),
         ]
 
         self.assertEqual(
@@ -227,10 +227,10 @@ class ComparisonTestCase(unittest.TestCase):
             ),
             TaggedEvaluationFilth(beg=5, end=10, text='12345', comparison_type='phone', locale='en_GB'),
             MergedFilth(
-                PhoneFilth(beg=5, end=9, text='1234', detector_name='phone', locale='en_US'),
-                TaggedEvaluationFilth(beg=5, end=9, text='1234', comparison_type='phone', locale='en_US'),
+                PhoneFilth(beg=12, end=16, text='1234', detector_name='phone', locale='en_US'),
+                TaggedEvaluationFilth(beg=12, end=16, text='1234', comparison_type='phone', locale='en_US'),
             ),
-            TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='phone', locale='en_US'),
+            TaggedEvaluationFilth(beg=20, end=25, text='12345', comparison_type='phone', locale='en_US'),
         ]
 
         self.assertEqual(
@@ -258,20 +258,20 @@ class ComparisonTestCase(unittest.TestCase):
             ),
             TaggedEvaluationFilth(beg=5, end=10, text='12345', comparison_type='phone', locale='en_GB'),
             MergedFilth(
-                PhoneFilth(beg=5, end=9, text='1234', detector_name='phone2', locale='en_US'),
-                TaggedEvaluationFilth(beg=5, end=9, text='1234', comparison_type='phone', locale='en_US'),
+                PhoneFilth(beg=12, end=16, text='1234', detector_name='phone2', locale='en_US'),
+                TaggedEvaluationFilth(beg=12, end=16, text='1234', comparison_type='phone', locale='en_US'),
             ),
-            TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='phone', locale='en_US'),
+            TaggedEvaluationFilth(beg=20, end=25, text='12345', comparison_type='phone', locale='en_US'),
         ]
 
         self.assertEqual(
             {
-                'macro avg': {'f1-score': 0.8333333333333333, 'precision': 1.0,'recall': 0.75, 'support': 3},
-                'micro avg': {'f1-score': 0.8, 'precision': 1.0, 'recall': 0.6666666666666666, 'support': 3},
+                'macro avg': {'f1-score': 0.6666666666666666, 'precision': 1.0,'recall': 0.5, 'support': 4},
+                'micro avg': {'f1-score': 0.6666666666666666, 'precision': 1.0, 'recall': 0.5, 'support': 4},
                 'phone:combined:en_GB': {'f1-score': 0.6666666666666666, 'precision': 1.0, 'recall': 0.5, 'support': 2},
-                'phone:combined:en_US': {'f1-score': 1.0, 'precision': 1.0, 'recall': 1.0, 'support': 1},
-                'samples avg': {'f1-score': 0.5, 'precision': 0.5, 'recall': 0.5, 'support': 3},
-                'weighted avg': {'f1-score': 0.7777777777777777, 'precision': 1.0, 'recall': 0.6666666666666666, 'support': 3}
+                'phone:combined:en_US': {'f1-score': 0.6666666666666666, 'precision': 1.0, 'recall': 0.5, 'support': 2},
+                'samples avg': {'f1-score': 0.5, 'precision': 0.5, 'recall': 0.5, 'support': 4},
+                'weighted avg': {'f1-score': 0.6666666666666666, 'precision': 1.0, 'recall': 0.5, 'support': 4}
             },
             scrubadub.comparison.get_filth_classification_report(
                 filths,

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -4,6 +4,7 @@ import scrubadub
 import scrubadub.comparison
 from scrubadub.filth.base import MergedFilth, Filth
 from scrubadub.filth.phone import PhoneFilth
+from scrubadub.filth.address import AddressFilth
 from scrubadub.filth.tagged import TaggedEvaluationFilth
 from scrubadub.detectors.base import Detector
 
@@ -11,6 +12,64 @@ class ComparisonTestCase(unittest.TestCase):
 
     def setUp(self):
         self.maxDiff = None
+
+
+    def test_grouper(self):
+        filths = [
+            MergedFilth(
+                PhoneFilth(beg=0, end=4, text='John', detector_name='phone_det'),
+                TaggedEvaluationFilth(beg=0, end=4, text='John', comparison_type='phone')
+            ),
+            TaggedEvaluationFilth(beg=5, end=10, text='Hello', comparison_type='name'),
+            AddressFilth(beg=100, end=103, text='123', detector_name='address_det'),
+        ]
+        grouper = scrubadub.comparison.FilthGrouper()
+        grouper.add_positions(filths)
+
+        self.assertEqual(3, len(grouper.types))
+
+        self.assertEqual(2, len(grouper.types['phone'].positions))
+        self.assertEqual(0, grouper.types['phone'].positions[0].beg)
+        self.assertEqual(4, grouper.types['phone'].positions[0].end)
+        self.assertEqual({('phone', 'phone_det', 'None')}, grouper.types['phone'].positions[0].detected)
+        self.assertEqual(set(), grouper.types['phone'].positions[0].tagged)
+        self.assertEqual(set(), grouper.types['phone'].positions[1].detected)
+        self.assertEqual({('phone', 'tagged', 'None')}, grouper.types['phone'].positions[1].tagged)
+
+        self.assertEqual(1, len(grouper.types['name'].positions))
+        self.assertEqual(5, grouper.types['name'].positions[0].beg)
+        self.assertEqual(10, grouper.types['name'].positions[0].end)
+        self.assertEqual({('name', 'tagged', 'None')}, grouper.types['name'].positions[0].tagged)
+        self.assertEqual(set(), grouper.types['name'].positions[0].detected)
+
+        self.assertEqual(1, len(grouper.types['address'].positions))
+        self.assertEqual(100, grouper.types['address'].positions[0].beg)
+        self.assertEqual(103, grouper.types['address'].positions[0].end)
+        self.assertEqual(set(), grouper.types['address'].positions[0].tagged)
+        self.assertEqual({('address', 'address_det', 'None')}, grouper.types['address'].positions[0].detected)
+
+        grouper.merge_positions()
+
+        self.assertEqual(3, len(grouper.types))
+
+        self.assertEqual(1, len(grouper.types['phone'].positions))
+        self.assertEqual(0, grouper.types['phone'].positions[0].beg)
+        self.assertEqual(4, grouper.types['phone'].positions[0].end)
+        self.assertEqual({('phone', 'phone_det', 'None')}, grouper.types['phone'].positions[0].detected)
+        self.assertEqual({('phone', 'tagged', 'None')}, grouper.types['phone'].positions[0].tagged)
+
+        self.assertEqual(1, len(grouper.types['name'].positions))
+        self.assertEqual(5, grouper.types['name'].positions[0].beg)
+        self.assertEqual(10, grouper.types['name'].positions[0].end)
+        self.assertEqual({('name', 'tagged', 'None')}, grouper.types['name'].positions[0].tagged)
+        self.assertEqual(set(), grouper.types['name'].positions[0].detected)
+
+        self.assertEqual(1, len(grouper.types['address'].positions))
+        self.assertEqual(100, grouper.types['address'].positions[0].beg)
+        self.assertEqual(103, grouper.types['address'].positions[0].end)
+        self.assertEqual(set(), grouper.types['address'].positions[0].tagged)
+        self.assertEqual({('address', 'address_det', 'None')}, grouper.types['address'].positions[0].detected)
+
 
     def test_comparison(self):
         """test basic comparison"""
@@ -27,17 +86,17 @@ class ComparisonTestCase(unittest.TestCase):
             TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='phone'),
         ]
 
-        self.assertEquals(
-            scrubadub.comparison.get_filth_classification_report(
-                filths,
-                output_dict=True,
-            ),
+        self.assertEqual(
             {
                 'macro avg': {'f1-score': 0.6666666666666666, 'precision': 1.0,'recall': 0.5, 'support': 4},
                 'micro avg': {'f1-score': 0.6666666666666666, 'precision': 1.0, 'recall': 0.5, 'support': 4},
                 'phone:phone:None': {'f1-score': 0.6666666666666666, 'precision': 1.0, 'recall': 0.5, 'support': 4},
                 'weighted avg': {'f1-score': 0.6666666666666666, 'precision': 1.0, 'recall': 0.5, 'support': 4}
             },
+            scrubadub.comparison.get_filth_classification_report(
+                filths,
+                output_dict=True,
+            ),
         )
 
     def test_text_output(self):
@@ -49,18 +108,17 @@ class ComparisonTestCase(unittest.TestCase):
             ),
             TaggedEvaluationFilth(beg=5, end=10, text='12345', comparison_type='phone'),
             MergedFilth(
-                PhoneFilth(beg=5, end=9, text='1234', detector_name='phone'),
-                TaggedEvaluationFilth(beg=5, end=9, text='1234', comparison_type='phone'),
+                PhoneFilth(beg=11, end=15, text='1234', detector_name='phone'),
+                TaggedEvaluationFilth(beg=11, end=15, text='1234', comparison_type='phone'),
             ),
-            TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='phone'),
+            TaggedEvaluationFilth(beg=16, end=21, text='12345', comparison_type='phone'),
         ]
         text = scrubadub.comparison.get_filth_classification_report(
             filths,
             output_dict=False,
         ).strip()
         print(text)
-        self.assertEquals(
-            text,
+        self.assertEqual(
             "filth     detector     locale    precision    recall  f1-score   support\n"
             "\n"
             "phone        phone       None         1.00      0.50      0.67         4\n"
@@ -68,6 +126,7 @@ class ComparisonTestCase(unittest.TestCase):
             "                      micro avg       1.00      0.50      0.67         4\n"
             "                      macro avg       1.00      0.50      0.67         4\n"
             "                   weighted avg       1.00      0.50      0.67         4\n".strip(),
+            text,
         )
 
     def test_false_positive(self):
@@ -82,18 +141,18 @@ class ComparisonTestCase(unittest.TestCase):
             TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='phone'),
         ]
 
-        self.assertEquals(
-            scrubadub.comparison.get_filth_classification_report(
-                filths,
-                # [PhoneDetector, KnownFilthDetector],
-                output_dict=True,
-            ),
+        self.assertEqual(
             {
                 'phone:phone_v1:None': {'precision': 0.5, 'recall': 0.3333333333333333, 'f1-score': 0.4, 'support': 3},
                 'micro avg': {'precision': 0.5, 'recall': 0.3333333333333333, 'f1-score': 0.4, 'support': 3},
                 'macro avg': {'precision': 0.5, 'recall': 0.3333333333333333, 'f1-score': 0.4, 'support': 3},
                 'weighted avg': {'precision': 0.5, 'recall': 0.3333333333333333, 'f1-score': 0.4000000000000001, 'support': 3}
             },
+            scrubadub.comparison.get_filth_classification_report(
+                filths,
+                # [PhoneDetector, KnownFilthDetector],
+                output_dict=True,
+            ),
         )
 
     def test_two_comparisons(self):
@@ -118,11 +177,7 @@ class ComparisonTestCase(unittest.TestCase):
             TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='temp'),
         ]
 
-        self.assertEquals(
-            scrubadub.comparison.get_filth_classification_report(
-                filths,
-                output_dict=True,
-            ),
+        self.assertEqual(
             {
                 'phone:phone:None': {'precision': 1.0, 'recall': 0.5, 'f1-score': 0.6666666666666666, 'support': 2},
                 'temp:temp:None': {'precision': 1.0, 'recall': 0.5, 'f1-score': 0.6666666666666666, 'support': 2},
@@ -131,6 +186,10 @@ class ComparisonTestCase(unittest.TestCase):
                 'weighted avg': {'precision': 1.0, 'recall': 0.5, 'f1-score': 0.6666666666666666, 'support': 4},
                 'samples avg': {'precision': 0.5, 'recall': 0.5, 'f1-score': 0.5, 'support': 4}
             },
+            scrubadub.comparison.get_filth_classification_report(
+                filths,
+                output_dict=True,
+            ),
         )
 
     def test_other_predefined_types(self):
@@ -143,18 +202,18 @@ class ComparisonTestCase(unittest.TestCase):
             TaggedEvaluationFilth(beg=5, end=10, text='Hello', comparison_type='word'),
         ]
 
-        self.assertEquals(
-            scrubadub.comparison.get_filth_classification_report(
-                filths,
-                # [PhoneDetector, KnownFilthDetector],
-                output_dict=True,
-            ),
+        self.assertEqual(
             {
                 'phone:phone:None': {'precision': 1.0, 'recall': 1.0, 'f1-score': 1.0, 'support': 1},
                 'micro avg': {'precision': 1.0, 'recall': 1.0, 'f1-score': 1.0, 'support': 1},
                 'macro avg': {'precision': 1.0, 'recall': 1.0, 'f1-score': 1.0, 'support': 1},
                 'weighted avg': {'precision': 1.0, 'recall': 1.0, 'f1-score': 1.0, 'support': 1}
             },
+            scrubadub.comparison.get_filth_classification_report(
+                filths,
+                # [PhoneDetector, KnownFilthDetector],
+                output_dict=True,
+            ),
 
         )
 
@@ -174,11 +233,7 @@ class ComparisonTestCase(unittest.TestCase):
             TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='phone', locale='en_US'),
         ]
 
-        self.assertEquals(
-            scrubadub.comparison.get_filth_classification_report(
-                filths,
-                output_dict=True,
-            ),
+        self.assertEqual(
             {
                 'macro avg': {'f1-score': 0.6666666666666666, 'precision': 1.0,'recall': 0.5, 'support': 4},
                 'micro avg': {'f1-score': 0.6666666666666666, 'precision': 1.0, 'recall': 0.5, 'support': 4},
@@ -187,6 +242,10 @@ class ComparisonTestCase(unittest.TestCase):
                 'samples avg': {'f1-score': 0.5, 'precision': 0.5, 'recall': 0.5, 'support': 4},
                 'weighted avg': {'f1-score': 0.6666666666666666, 'precision': 1.0, 'recall': 0.5, 'support': 4}
             },
+            scrubadub.comparison.get_filth_classification_report(
+                filths,
+                output_dict=True,
+            ),
         )
 
     def test_overall(self):
@@ -202,10 +261,10 @@ class ComparisonTestCase(unittest.TestCase):
                 PhoneFilth(beg=5, end=9, text='1234', detector_name='phone2', locale='en_US'),
                 TaggedEvaluationFilth(beg=5, end=9, text='1234', comparison_type='phone', locale='en_US'),
             ),
-            TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='phone2', locale='en_US'),
+            TaggedEvaluationFilth(beg=15, end=20, text='12345', comparison_type='phone', locale='en_US'),
         ]
 
-        self.assertEquals(
+        self.assertEqual(
             {
                 'macro avg': {'f1-score': 0.8333333333333333, 'precision': 1.0,'recall': 0.75, 'support': 3},
                 'micro avg': {'f1-score': 0.8, 'precision': 1.0, 'recall': 0.6666666666666666, 'support': 3},
@@ -237,18 +296,18 @@ class ComparisonTestCase(unittest.TestCase):
             TempFilth(beg=100, end=103, text='123', detector_name='temp'),
         ]
 
-        self.assertEquals(
-            scrubadub.comparison.get_filth_classification_report(
-                filths,
-                # [PhoneDetector, KnownFilthDetector],
-                output_dict=True,
-            ),
+        self.assertEqual(
             {
                 'phone:phone:None': {'precision': 1.0, 'recall': 1.0, 'f1-score': 1.0, 'support': 1},
                 'micro avg': {'precision': 1.0, 'recall': 1.0, 'f1-score': 1.0, 'support': 1},
                 'macro avg': {'precision': 1.0, 'recall': 1.0, 'f1-score': 1.0, 'support': 1},
                 'weighted avg': {'precision': 1.0, 'recall': 1.0, 'f1-score': 1.0, 'support': 1}
             },
+            scrubadub.comparison.get_filth_classification_report(
+                filths,
+                # [PhoneDetector, KnownFilthDetector],
+                output_dict=True,
+            ),
         )
 
     def test_empty(self):
@@ -281,17 +340,47 @@ class ComparisonTestCase(unittest.TestCase):
         dataframe = scrubadub.comparison.get_filth_dataframe(
             filths,
         )
-        self.assertEquals(dataframe.shape[0], 4)
-        self.assertEquals(dataframe['filth_type'].fillna('none').values.tolist(), ['phone', 'phone', 'none', 'none'])
-        self.assertEquals(dataframe['beg'].fillna('none').values.tolist(), [0, 4, 'none', 'none'])
-        self.assertEquals(dataframe['end'].fillna('none').values.tolist(), [4, 9, 'none', 'none'])
-        self.assertEquals(dataframe['known_beg'].fillna('none').values.tolist(), [0, 5, 5, 15])
-        self.assertEquals(dataframe['known_end'].fillna('none').values.tolist(), [4, 9, 10, 20])
-        self.assertEquals(dataframe['exact_match'].fillna('none').values.tolist(), [True, False, False, False])
-        self.assertEquals(dataframe['partial_match'].fillna('none').values.tolist(), [True, True, False, False])
-        self.assertEquals(dataframe['true_positive'].fillna('none').values.tolist(), [True, True, False, False])
-        self.assertEquals(dataframe['false_positive'].fillna('none').values.tolist(), [False, False, False, False])
-        self.assertEquals(dataframe['false_negative'].fillna('none').values.tolist(), [False, False, True, True])
+        self.assertEqual(4, dataframe.shape[0])
+        self.assertEqual(
+            ['phone', 'phone', 'none', 'none'],
+            dataframe['filth_type'].fillna('none').values.tolist(),
+        )
+        self.assertEqual(
+            [0, 4, 'none', 'none'],
+            dataframe['beg'].fillna('none').values.tolist(),
+        )
+        self.assertEqual(
+            [4, 9, 'none', 'none'],
+            dataframe['end'].fillna('none').values.tolist(),
+        )
+        self.assertEqual(
+            [0, 5, 5, 15],
+            dataframe['known_beg'].fillna('none').values.tolist(),
+        )
+        self.assertEqual(
+            [4, 9, 10, 20],
+            dataframe['known_end'].fillna('none').values.tolist(),
+        )
+        self.assertEqual(
+            [True, False, False, False],
+            dataframe['exact_match'].fillna('none').values.tolist(),
+        )
+        self.assertEqual(
+            [True, True, False, False],
+            dataframe['partial_match'].fillna('none').values.tolist(),
+        )
+        self.assertEqual(
+            [True, True, False, False],
+            dataframe['true_positive'].fillna('none').values.tolist(),
+        )
+        self.assertEqual(
+            [False, False, False, False],
+            dataframe['false_positive'].fillna('none').values.tolist(),
+        )
+        self.assertEqual(
+            [False, False, True, True],
+            dataframe['false_negative'].fillna('none').values.tolist(),
+        )
 
     def test_make_document(self):
         document, known_filths = scrubadub.comparison.make_fake_document(paragraphs=1, seed=0)
@@ -306,5 +395,5 @@ class ComparisonTestCase(unittest.TestCase):
         for filth_item in known_filths:
             self.assertIn(filth_item['match'], document)
             total_len += len(filth_item['match'])
-            self.assertEquals(filth_item['filth_type'], 'email')
+            self.assertEqual(filth_item['filth_type'], 'email')
         self.assertTrue(len(document) > 2 * total_len)

--- a/tests/test_comparison_classes.py
+++ b/tests/test_comparison_classes.py
@@ -1,0 +1,214 @@
+import unittest
+
+import scrubadub
+import scrubadub.comparison
+from scrubadub.comparison import TextPosition, FilthTypePositions, FilthGrouper
+from scrubadub.filth.base import MergedFilth, Filth
+from scrubadub.filth.phone import PhoneFilth
+from scrubadub.filth.address import AddressFilth
+from scrubadub.filth.tagged import TaggedEvaluationFilth
+from scrubadub.detectors.base import Detector
+
+class ComparisonTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_text_position(self):
+        filth = PhoneFilth(beg=0, end=4, text='1234', detector_name='phone', locale='en_GB', document_name='test.txt')
+        tp = TextPosition(filth, FilthGrouper.grouping_default)
+
+        self.assertEqual(filth.beg, tp.beg)
+        self.assertEqual(filth.end, tp.end)
+        self.assertEqual(
+            {('phone', 'phone', 'en_GB')},
+            tp.detected,
+        )
+        self.assertEqual(set(), tp.tagged)
+        self.assertEqual(filth.document_name, tp.document_name)
+
+    def test_text_position_function(self):
+        filth = PhoneFilth(beg=0, end=4, text='1234', detector_name='phone', locale='en_GB', document_name='test.txt')
+        tp = TextPosition(filth, lambda x: {1:1, 2:2, 3:3})
+
+        self.assertEqual(
+            {(1, 2, 3)},
+            tp.detected,
+        )
+
+    def test_text_position_merge(self):
+        filth_a = PhoneFilth(
+            beg=0, end=4, text='1234', detector_name='phone_a', locale='en_GB', document_name='test.txt'
+        )
+        filth_b = PhoneFilth(
+            beg=3, end=6, text='1234', detector_name='phone_b', locale='en_GB', document_name='test.txt'
+        )
+
+        tp_a = TextPosition(filth_a, FilthGrouper.grouping_default)
+        tp_b = TextPosition(filth_b, FilthGrouper.grouping_default)
+        tp_a.merge(tp_b)
+
+        self.assertEqual(0, tp_a.beg)
+        self.assertEqual(6, tp_a.end)
+
+        self.assertEqual(
+            {
+                ('phone', 'phone_a', 'en_GB'),
+                ('phone', 'phone_b', 'en_GB'),
+            },
+            tp_a.detected,
+        )
+        self.assertEqual(set(), tp_a.tagged)
+
+    def test_text_position_merge_files(self):
+        filth_a = PhoneFilth(
+            beg=0, end=4, text='1234', detector_name='phone_a', locale='en_GB', document_name='test1.txt'
+        )
+        filth_b = PhoneFilth(
+            beg=3, end=6, text='1234', detector_name='phone_b', locale='en_GB', document_name='test2.txt'
+        )
+
+        tp_a = TextPosition(filth_a, FilthGrouper.grouping_default)
+        tp_b = TextPosition(filth_b, FilthGrouper.grouping_default)
+
+        with self.assertRaises(ValueError):
+            tp_a.merge(tp_b)
+
+    def test_text_position_merge_ranges(self):
+        filth_a = PhoneFilth(
+            beg=0, end=4, text='1234', detector_name='phone_a', locale='en_GB', document_name='test.txt'
+        )
+        filth_b = PhoneFilth(
+            beg=10, end=14, text='1234', detector_name='phone_b', locale='en_GB', document_name='test.txt'
+        )
+
+        tp_a = TextPosition(filth_a, FilthGrouper.grouping_default)
+        tp_b = TextPosition(filth_b, FilthGrouper.grouping_default)
+
+        with self.assertRaises(ValueError):
+            tp_a.merge(tp_b)
+
+    def test_text_position_repr(self):
+        filth = PhoneFilth(beg=0, end=4, text='1234', detector_name='phone_a', locale='en_GB', document_name='test.txt')
+        tp = TextPosition(filth, FilthGrouper.grouping_default)
+        self.assertEqual(
+            "<TextPosition beg=0 end=4 tagged=set() detected={('phone', 'phone_a', 'en_GB')} document_name='test.txt'>",
+            tp.__repr__()
+        )
+
+    def test_filth_type(self):
+        filth_a = PhoneFilth(
+            beg=0, end=4, text='1234', detector_name='phone_a', locale='en_GB', document_name='test.txt'
+        )
+        filth_b = PhoneFilth(
+            beg=2, end=6, text='1234', detector_name='phone_b', locale='en_GB', document_name='test.txt'
+        )
+        filth_c = PhoneFilth(
+            beg=10, end=14, text='1234', detector_name='phone_b', locale='en_GB', document_name='test.txt'
+        )
+
+        ft = FilthTypePositions(grouping_function=FilthGrouper.grouping_default, filth_type='phone')
+        ft.add_filth(filth_c)
+        ft.add_filth(filth_a)
+        ft.add_filth(filth_b)
+        self.assertEqual(3, len(ft.positions))
+        self.assertEqual(10, ft.positions[0].beg)
+        self.assertEqual(0, ft.positions[1].beg)
+        self.assertEqual(2, ft.positions[2].beg)
+        self.assertEqual(['filth_type', 'detector_name', 'locale'], ft.column_names)
+
+        ft.merge_positions()
+        self.assertEqual(2, len(ft.positions))
+        self.assertEqual(10, ft.positions[1].beg)
+        self.assertEqual(0, ft.positions[0].beg)
+        self.assertEqual(6, ft.positions[0].end)
+        self.assertEqual(
+            {
+                ('phone', 'phone_a', 'en_GB'),
+                ('phone', 'phone_b', 'en_GB'),
+            },
+            ft.positions[0].detected,
+        )
+
+        df = ft.get_counts()
+        self.assertEqual(['filth_type', 'detector_name', 'locale'], df.columns.names)
+        self.assertEqual(
+            {
+                ('phone', 'phone_b', 'en_GB'),
+                ('phone', 'phone_a', 'en_GB'),
+            },
+            set(df.columns.values.tolist()),
+        )
+        self.assertEqual([1, 0], df[('phone', 'phone_a', 'en_GB')].values.tolist())
+        self.assertEqual([1, 1], df[('phone', 'phone_b', 'en_GB')].values.tolist())
+
+    def test_filth_type_touching(self):
+        filth_a = PhoneFilth(
+            beg=0, end=4, text='1234', detector_name='phone_a', locale='en_GB', document_name='test.txt'
+        )
+        filth_b = PhoneFilth(
+            beg=2, end=6, text='1234', detector_name='phone_b', locale='en_GB', document_name='test.txt'
+        )
+        filth_c = PhoneFilth(
+            beg=6, end=10, text='1234', detector_name='phone_b', locale='en_GB', document_name='test.txt'
+        )
+
+        ft = FilthTypePositions(grouping_function=FilthGrouper.grouping_default, filth_type='phone')
+        ft.add_filth(filth_c)
+        ft.add_filth(filth_a)
+        ft.add_filth(filth_b)
+        ft.merge_positions()
+
+        self.assertEqual(2, len(ft.positions))
+
+
+    def test_filth_grouper(self):
+        filths = [
+            MergedFilth(
+                PhoneFilth(beg=0, end=4, text='1234', detector_name='phone', locale='en_GB'),
+                TaggedEvaluationFilth(beg=0, end=4, text='1234', comparison_type='phone', locale='en_GB'),
+            ),
+            TaggedEvaluationFilth(beg=5, end=10, text='12345', comparison_type='phone', locale='en_GB'),
+            MergedFilth(
+                PhoneFilth(beg=12, end=16, text='1234', detector_name='phone', locale='en_US'),
+                TaggedEvaluationFilth(beg=12, end=16, text='1234', comparison_type='phone', locale='en_US'),
+            ),
+            TaggedEvaluationFilth(beg=20, end=25, text='12345', comparison_type='phone', locale='en_US'),
+            TaggedEvaluationFilth(beg=30, end=35, text='12345', comparison_type='name', locale='en_US'),
+        ]
+        fg = FilthGrouper(combine_detectors=True, groupby_documents=False, filth_types=None)
+        self.assertEqual(fg.grouping_function, FilthGrouper.grouping_combined)
+        fg = FilthGrouper(combine_detectors=False, groupby_documents=False, filth_types=None)
+        self.assertEqual(fg.grouping_function, FilthGrouper.grouping_default)
+
+        fg.add_filths(filths)
+        print(fg)
+        self.assertEqual(['phone', 'name'], list(fg.types.keys()))
+        self.assertEqual(1, len(fg.types['name'].positions))
+        self.assertEqual(6, len(fg.types['phone'].positions))
+
+        fg.merge_positions()
+        self.assertEqual(1, len(fg.types['name'].positions))
+        self.assertEqual(4, len(fg.types['phone'].positions))
+
+        fg_from_list = FilthGrouper.from_filth_list(filths)
+        self.assertEqual(list(fg.types.keys()), list(fg_from_list.types.keys()))
+
+        df = fg.get_counts()
+        print(df)
+        self.assertEqual(['filth_type', 'detector_name', 'locale'], df.columns.names)
+        self.assertEqual(
+            [
+                ('name', 'tagged', 'en_US'),
+                ('phone', 'phone', 'en_GB'),
+                ('phone', 'phone', 'en_US'),
+                ('phone', 'tagged', 'en_GB'),
+                ('phone', 'tagged', 'en_US')
+            ],
+            df.columns.values.tolist(),
+        )
+        self.assertEqual([0, 0, 0, 0, 1], df[('name', 'tagged', 'en_US')].values.tolist())
+        self.assertEqual([1, 0, 0, 0, 0], df[('phone', 'phone', 'en_GB')].values.tolist())
+        self.assertEqual([0, 0, 1, 0, 0], df[('phone', 'phone', 'en_US')].values.tolist())
+        self.assertEqual([1, 1, 0, 0, 0], df[('phone', 'tagged', 'en_GB')].values.tolist())
+        self.assertEqual([0, 0, 1, 1, 0], df[('phone', 'tagged', 'en_US')].values.tolist())

--- a/tests/test_comparison_classes.py
+++ b/tests/test_comparison_classes.py
@@ -115,7 +115,7 @@ class ComparisonTestCase(unittest.TestCase):
         self.assertEqual(10, ft.positions[0].beg)
         self.assertEqual(0, ft.positions[1].beg)
         self.assertEqual(2, ft.positions[2].beg)
-        self.assertEqual(['filth_type', 'detector_name', 'locale'], ft.column_names)
+        self.assertEqual(['filth', 'detector', 'locale'], ft.column_names)
 
         ft.merge_positions()
         self.assertEqual(2, len(ft.positions))
@@ -131,7 +131,7 @@ class ComparisonTestCase(unittest.TestCase):
         )
 
         df = ft.get_counts()
-        self.assertEqual(['filth_type', 'detector_name', 'locale'], df.columns.names)
+        self.assertEqual(['filth', 'detector', 'locale'], df.columns.names)
         self.assertEqual(
             {
                 ('phone', 'phone_b', 'en_GB'),
@@ -196,7 +196,7 @@ class ComparisonTestCase(unittest.TestCase):
 
         df = fg.get_counts()
         print(df)
-        self.assertEqual(['filth_type', 'detector_name', 'locale'], df.columns.names)
+        self.assertEqual(['filth', 'detector', 'locale'], df.columns.names)
         self.assertEqual(
             [
                 ('name', 'tagged', 'en_US'),


### PR DESCRIPTION
Previously the classification report did not handle overlapping filth well. If two names were detected in an email address eg: jane.doe@example.com, jane and doe would be counted as one name instead of two, because the email address joined them together. This had the effect that adding an email detector could change the count of the number of names found, which is not what you would expect to happen. In the process of refactoring this I also made it more flexible so that we can group by arbitrary attributes of the Filth, for now this has resulted in the ability to show the accuracies on a per file basis.