### PR TITLE
Move to openpyxl

### DIFF
--- a/requirements/python-dev
+++ b/requirements/python-dev
@@ -22,5 +22,5 @@ click
 python-magic
 python-dotenv
 azure-storage-blob
-xlrd<2
+openpyxl
 tabulate


### PR DESCRIPTION
Move to openpyxl from xlrd as xlrd has dropped xls support, this stops a warning being displayed.