### PR TITLE
Improve spacy trf model recall

### DIFF
--- a/scrubadub/detectors/spacy.py
+++ b/scrubadub/detectors/spacy.py
@@ -246,8 +246,8 @@ class SpacyEntityDetector(Detector):
 
         spacy_docs = self._run_spacy(document_list=preprocessed_docs, document_names=document_names)
 
-        self.yielded_filth = set()
         for doc_name, doc, text in zip(document_names, spacy_docs, document_list):
+            self.yielded_filth = set()
             for ent in doc.ents:
                 yield from self._yield_filth(doc_name, text, ent)
         self.yielded_filth = None


### PR DESCRIPTION
This fixes a bug that caused the transformer recall to be 15% instead of 62% on names.

This was happening as I was not searching for filth if I had already seen it in any of the files that had been processed in the same batch. So if John was foind in fil 1, it wouldnt be searched for in files 2 onwards. Resetting this at the start of each file fixes this.