### PR TITLE
Ensure Filth have non-zero length

### DIFF
--- a/scrubadub/filth/base.py
+++ b/scrubadub/filth/base.py
@@ -54,6 +54,11 @@ class Filth(object):
         self.replacement_string = replacement_string  # type: Optional[str]
         self.locale = locale  # type: Optional[str]
 
+        if self.beg >= self.end:
+            raise ValueError(
+                f"Creating invalid filth (self.beg >= self.end): {self}"
+            )
+
     @property
     def placeholder(self) -> str:
         return self.type.upper()

--- a/scrubadub/scrubbers.py
+++ b/scrubadub/scrubbers.py
@@ -289,17 +289,21 @@ class Scrubber(object):
             self, text: str, filth_list: Sequence[Filth], document_name: Optional[str], **kwargs
     ) -> str:
         filth_list = [filth for filth in filth_list if filth.document_name == document_name]
+        if len(filth_list) == 0:
+            return text
+
         filth_list = self._sort_filths(filth_list)  # TODO: expensive sort may not be needed
+        filth = None  # type: Optional[Filth]
         clean_chunks = []
-        filth = Filth()
         for next_filth in filth_list:
-            clean_chunks.append(text[filth.end:next_filth.beg])
+            clean_chunks.append(text[(0 if filth is None else filth.end):next_filth.beg])
             if next_filth.replacement_string is not None:
                 clean_chunks.append(next_filth.replacement_string)
             else:
                 clean_chunks.append(next_filth.replace_with(**kwargs))
             filth = next_filth
-        clean_chunks.append(text[filth.end:])
+        if filth is not None:
+            clean_chunks.append(text[filth.end:])
         return u''.join(clean_chunks)
 
     def _post_process_filth_list(self, filth_list: Sequence[Filth]) -> Sequence[Filth]:

--- a/tests/test_filth.py
+++ b/tests/test_filth.py
@@ -8,7 +8,7 @@ class FilthTestCase(unittest.TestCase):
 
     def test_disallowed_replace_with(self):
         """replace_with should fail gracefully"""
-        filth = Filth()
+        filth = Filth(beg=0, end=3, text='asd')
         with self.assertRaises(InvalidReplaceWith):
             filth.replace_with('surrogate')
         with self.assertRaises(InvalidReplaceWith):


### PR DESCRIPTION
This tweaks a few bit to require that Filth cannot have zero size. This will raise an error on Filth class initialization if you make a zero length filth, useful for when a detector is returning invalid Filth.