### PR TITLE
Improve false positive rate in title detector

### DIFF
--- a/scrubadub/__init__.py
+++ b/scrubadub/__init__.py
@@ -8,7 +8,7 @@ from . import detectors
 from . import post_processors
 from .filth import Filth
 
-__version__ = VERSION = "2.0.0.rc0"
+__version__ = VERSION = "2.0.0.rc1"
 __all__ = [
     'Scrubber', 'filth', 'detectors', 'post_processors', 'clean', 'clean_documents', 'list_filth',
     'list_filth_documents',

--- a/scrubadub/detectors/spacy.py
+++ b/scrubadub/detectors/spacy.py
@@ -202,7 +202,7 @@ class SpacyEntityDetector(Detector):
                               "preprocessing the text by removing non-words and reducing spaces. Skipping file: {}"
                     logger = logging.getLogger('scrubadub.detectors.spacy.SpacyEntityDetector')
                     logger.warning(message.format(document_names[i]))
-                    spacy_doc = list(self.nlp.pipe(' '))[0]
+                    spacy_doc = list(self.nlp.pipe([' ']))[0]
                 else:
                     raise e
             except StopIteration:

--- a/scrubadub/detectors/spacy.py
+++ b/scrubadub/detectors/spacy.py
@@ -180,7 +180,7 @@ class SpacyEntityDetector(Detector):
                 tokenizer = transformer_model.model.attrs['tokenizer']
                 tokenizer.deprecation_warnings['sequence-length-is-longer-than-the-specified-maximum'] = False
 
-        generator = self.nlp.pipe(document_list)
+        generator = self.nlp.pipe(document_list)  # type: Generator[spacy.tokens.doc.Doc]
 
         if len(transformer_stages) > 0:
             transformer_model = cast(spacy_transformers.pipeline_component.Transformer, transformer_stages[0])

--- a/scrubadub/detectors/spacy.py
+++ b/scrubadub/detectors/spacy.py
@@ -180,7 +180,10 @@ class SpacyEntityDetector(Detector):
                 tokenizer = transformer_model.model.attrs['tokenizer']
                 tokenizer.deprecation_warnings['sequence-length-is-longer-than-the-specified-maximum'] = False
 
-        generator = self.nlp.pipe(document_list)  # type: Generator[spacy.tokens.doc.Doc]
+        # The type of the below should be type: Generator[spacy.tokens.doc.Doc]
+        # However there is currently a spacy bug https://github.com/explosion/spaCy/issues/8772
+        # Temporarily removed typing here to make mypy pass
+        generator = self.nlp.pipe(document_list)  # type: ignore
 
         if len(transformer_stages) > 0:
             transformer_model = cast(spacy_transformers.pipeline_component.Transformer, transformer_stages[0])
@@ -202,7 +205,11 @@ class SpacyEntityDetector(Detector):
                               "preprocessing the text by removing non-words and reducing spaces. Skipping file: {}"
                     logger = logging.getLogger('scrubadub.detectors.spacy.SpacyEntityDetector')
                     logger.warning(message.format(document_names[i]))
-                    spacy_doc = list(self.nlp.pipe([' ']))[0]
+
+                    # The type of the below should be type: spacy.tokens.doc.Doc
+                    # However there is currently a spacy bug https://github.com/explosion/spaCy/issues/8772
+                    # Temporarily removed typing here to make mypy pass
+                    spacy_doc = next(self.nlp.pipe([' ']))  # type: ignore
                 else:
                     raise e
             except StopIteration:

--- a/scrubadub/detectors/spacy_name_title.py
+++ b/scrubadub/detectors/spacy_name_title.py
@@ -80,7 +80,8 @@ class SpacyNameDetector(SpacyEntityDetector):
     >>> import scrubadub, scrubadub.detectors.spacy_name_title
     >>> scrubadub.detectors.spacy_name_title.SpacyNameDetector.NOUN_TAGS['de'] = ['NN', 'NE', 'NNE']
     >>> scrubadub.detectors.spacy_name_title.SpacyNameDetector.NAME_PREFIXES['de'] = ['frau', 'herr']
-    >>> detector = scrubadub.detectors.spacy_name_title.SpacyNameDetector(locale='de_DE', model='de_core_news_sm')
+    >>> detector = scrubadub.detectors.spacy_name_title.SpacyNameDetector(locale='de_DE', model='de_core_news_sm',
+    ...     include_spacy=False)
     >>> scrubber = scrubadub.Scrubber(detector_list=[detector], locale='de_DE')
     >>> scrubber.clean("bleib dort Frau Schmidt")
     'bleib dort {{NAME+NAME}}'

--- a/scrubadub/detectors/spacy_name_title.py
+++ b/scrubadub/detectors/spacy_name_title.py
@@ -143,7 +143,7 @@ class SpacyNameDetector(SpacyEntityDetector):
 
     @staticmethod
     def _get_affix_and_spacy_entities(doc: spacy.tokens.doc.Doc) -> Iterable[spacy.tokens.span.Span]:
-        return (doc.ents + doc._.person_titles)
+        return (doc.ents + tuple(doc._.person_titles))
 
     @staticmethod
     def find_names(doc: spacy.tokens.doc.Doc, tokens: Sequence[spacy.tokens.token.Token],
@@ -204,7 +204,7 @@ class SpacyNameDetector(SpacyEntityDetector):
 
     @staticmethod
     def _remove_trigger_tokens(doc: spacy.tokens.doc.Doc,
-                               tokens: Sequence[spacy.tokens.token.Token]) -> List[spacy.tokens.token.Token]:
+                               tokens: Sequence[spacy.tokens.token.Token]) -> Sequence[spacy.tokens.token.Token]:
         """Remove all trigger words from the start and end of a sequence of tokens."""
         tokens_to_remove = []  # type: List[str]
 

--- a/tests/test_detector_spacy_name_title.py
+++ b/tests/test_detector_spacy_name_title.py
@@ -53,11 +53,23 @@ class SpacyExpandPersonTitleTestCase(unittest.TestCase, BaseTestCase):
             (18, 33),
             (6, 16),
         ]
-        for doc, beg_end in zip(doc_list, beg_end_list):
+        count_list = [2, 2, 2, 2, 2, 1]
+        for doc, beg_end, count in zip(doc_list, beg_end_list, count_list):
             filth_list = list(self.detector.iter_filth(doc))
-            self.assertEqual(2, len(filth_list), doc)
+            self.assertEqual(count, len(filth_list), doc)
             self.assertIsInstance(filth_list[0], NameFilth)
             self.assertEqual(beg_end, (filth_list[0].beg, filth_list[0].end))
+
+    def test_bad_examples(self):
+        doc_list = [
+            "Take it from the office supplies as soon as possible!",
+            '"Hi" said John.',
+            'Hello? Mike? Are you there?',
+            "When will you get out from Hospital?"
+        ]
+        for doc in doc_list:
+            filth_list = list(self.detector.iter_filth(doc))
+            self.assertEqual(0, len(filth_list), doc)
 
     def test_doc(self):
         doc = """


### PR DESCRIPTION
Improve false positive rate in title detector by removing 'from' prefix and improve the logic of the token iteration such that it only finds tokens directly adjacent to the prefix/suffix that was detected.

Also closes #122 