### PR TITLE
Fix issue: The 'sklearn' PyPI package is deprecated, use 'scikit-learn'

### DIFF
--- a/requirements/python
+++ b/requirements/python
@@ -16,7 +16,7 @@ dateparser
 catalogue
 
 # For scrubadub.comparison
-sklearn
+scikit-learn
 
 typing_extensions
 faker


### PR DESCRIPTION
When trying to install the package, the following error is thrown: `The 'sklearn' PyPI package is deprecated, use 'scikit-learn'`, as described in #142 

This fix solves this issue.
